### PR TITLE
Removed HullDesign Subcategory

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,8 @@ Error message and password prompt
 
 <li>Contents</li>
 
+<li>Designing the Hull in SolidWorks</li>
+
 <li>Dive</li>
 
 <li>Docs</li>
@@ -276,8 +278,6 @@ Error message and password prompt
 <li>Git Basic Usage</li>
 
 <li>Hull</li>
-
-<li>HullDesign</li>
 
 <li>Main</li>
 
@@ -9815,7 +9815,7 @@ Error message and password prompt
 <div title="$:/status/RequireReloadDueToPluginChange">
 <pre>no</pre>
 </div>
-<div created="20200808183655996" list="[[02. Making a Category]] [[01. TiddlyWiki YouTube Tutorial]] [[00. So You Just Opened TiddlyWiki]] Tutorials Main HullDesign Hull" modified="20200808184901030" title="$:/StoryList">
+<div created="20200808190103778" list="Main Hull [[Designing the Hull in SolidWorks]]" modified="20200808190110135" title="$:/StoryList">
 <pre></pre>
 </div>
 <div plugin-type="info" title="$:/temp/info-plugin" type="application/json">
@@ -10169,6 +10169,11 @@ There you go, you now know everything you need to begin saving your wiki entries
 <div created="20200709023147891" modified="20200709023200729" tags="" title="Contents">
 <pre>&lt;&lt;toc-selective-expandable 'contents' sort[title]&gt;&gt;</pre>
 </div>
+<div created="20200808180550617" modified="20200808190151321" tags="Hull Design" title="Designing the Hull in SolidWorks">
+<pre>I will update this tutorial soon :)
+
+</pre>
+</div>
 <div created="20200709020554808" modified="20200709023333007" tags="Teams" title="Dive">
 <pre>&lt;&lt;toc-selective-expandable 'Dive' sort[title]&gt;&gt;</pre>
 </div>
@@ -10189,13 +10194,6 @@ There you go, you now know everything you need to begin saving your wiki entries
 </div>
 <div created="20200709020800722" modified="20200709023404286" tags="Teams" title="Hull">
 <pre>&lt;&lt;toc-selective-expandable 'Hull' sort[title]&gt;&gt;</pre>
-</div>
-<div created="20200808180550617" modified="20200808184954192" tags="Hull" title="HullDesign">
-<pre>&lt;div class=&quot;tc-table-of-contents&quot;&gt;
-&lt;&lt;toc-selective-expandable 'HullDesign' sort[title]&gt;&gt;
-&lt;/div&gt;
-
-</pre>
 </div>
 <div created="20200702023642247" list-before="$:/core/ui/SideBar/Open" modified="20200709024728231" tags="$:/tags/SideBar" title="Main">
 <pre>&lt;div class=&quot;tc-table-of-contents&quot;&gt;


### PR DESCRIPTION
Instead of splitting up Hull into "Design" and "Manufacturing" subcategories - we have decided to just make those tags instead.